### PR TITLE
Add Chrome MV3 manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ In Thunderbird, uBlock Origin does not affect emails, just feeds.
 
 uBO should be compatible with any Chromium-based browser.
 
+Starting with Chrome 139, only Manifest v3 extensions are supported. To build
+the MV3 version of uBlock Origin run `make mv3-chromium`.
+
 #### All Programs
 
 Do **NOT** use uBO with any other content blocker. uBO [performs][Performance] as well as or better than most popular blockers. Other blockers can prevent uBO's privacy or anti-blocker-defusing features from working correctly.

--- a/platform/chromium/manifest_v3.json
+++ b/platform/chromium/manifest_v3.json
@@ -1,0 +1,91 @@
+{
+  "action": {
+    "default_icon": {
+      "16": "img/icon_16.png",
+      "32": "img/icon_32.png",
+      "64": "img/icon_64.png"
+    },
+    "default_popup": "popup.html"
+  },
+  "author": "Raymond Hill",
+  "background": {
+      "service_worker": "/js/background.js",
+      "type": "module"
+   },
+  "commands": {
+    "enter-zapper-mode": {
+      "description": "__MSG_zapperTipEnter__"
+    },
+    "enter-picker-mode": {
+      "description": "__MSG_pickerTipEnter__"
+    }
+  },
+  "declarative_net_request": {
+    "rule_resources": [
+    ]
+  },
+  "default_locale": "en",
+  "description": "__MSG_extShortDesc__",
+  "host_permissions": [
+    "<all_urls>"
+  ],
+  "icons": {
+    "16": "img/icon_16.png",
+    "32": "img/icon_32.png",
+    "64": "img/icon_64.png",
+    "128": "img/icon_128.png"
+  },
+  "manifest_version": 3,
+  "minimum_chrome_version": "122.0",
+  "name": "__MSG_extName__",
+  "options_page": "dashboard.html",
+  "permissions": [
+    "activeTab",
+    "declarativeNetRequest",
+    "scripting",
+    "storage"
+  ],
+  "short_name": "uBlock₀",
+  "storage": {
+    "managed_schema": "managed_storage.json"
+  },
+  "version": "1.0",
+  "web_accessible_resources": [
+    {
+      "resources": [
+        "/strictblock.html"
+      ],
+      "matches": [
+        "<all_urls>"
+      ],
+      "use_dynamic_url": true
+    },
+    {
+      "resources": [
+        "/zapper-ui.html"
+      ],
+      "matches": [
+        "<all_urls>"
+      ],
+      "use_dynamic_url": true
+    },
+    {
+      "resources": [
+        "/picker-ui.html"
+      ],
+      "matches": [
+        "<all_urls>"
+      ],
+      "use_dynamic_url": true
+    },
+    {
+      "resources": [
+        "/unpicker-ui.html"
+      ],
+      "matches": [
+        "<all_urls>"
+      ],
+      "use_dynamic_url": true
+    }
+  ]
+}

--- a/platform/mv3/safari/patch-ruleset.js
+++ b/platform/mv3/safari/patch-ruleset.js
@@ -19,15 +19,6 @@
     Home: https://github.com/gorhill/uBlock
 */
 
-function patchRuleWithRequestDomains(rule, out) {
-    const requestDomains = rule.condition.requestDomains;
-    delete rule.condition.requestDomains;
-    for ( const domain of requestDomains ) {
-        const newRule = structuredClone(rule);
-        newRule.condition.urlFilter = `||${domain}^`;
-        out.push(newRule);
-    }
-}
 
 export function patchRuleset(ruleset) {
     const out = [];


### PR DESCRIPTION
### **User description**
## Summary
- provide a Manifest V3 example in `platform/chromium/manifest_v3.json`
- note MV3 build in README
- clean up unused function in Safari ruleset patch

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68803a9ca2b48327bc138d00a1a39d28


___

### **Description**
- Introduced a new Manifest V3 configuration for uBlock Origin in `platform/chromium/manifest_v3.json`.
- Updated the README to reflect the support for Manifest V3 starting from Chrome 139 and provided build instructions.
- Cleaned up the Safari ruleset patch by removing an unused function.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update README with MV3 support details</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md
<li>Added note about MV3 support starting from Chrome 139.<br> <li> Provided instructions to build the MV3 version of uBlock Origin.<br>


</details>


  </td>
  <td><a href="https://github.com/erik-ingwersen-ey/uBlock/pull/1/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest_v3.json</strong><dd><code>Add Manifest V3 configuration for uBlock Origin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/chromium/manifest_v3.json
<li>Added a new Manifest V3 configuration for uBlock Origin.<br> <li> Defined action, background, permissions, and web accessible resources.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/erik-ingwersen-ey/uBlock/pull/1/files#diff-71e3a1f3172f039ae4865306ab37d8b29e6836b5fff78e47aab86f1383f8b7c4">+91/-0</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>patch-ruleset.js</strong><dd><code>Clean up Safari ruleset patching code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

platform/mv3/safari/patch-ruleset.js
<li>Removed unused function for patching rules with request domains.<br> <li> Cleaned up code related to Safari ruleset patching.<br>


</details>


  </td>
  <td><a href="https://github.com/erik-ingwersen-ey/uBlock/pull/1/files#diff-8ac322168214b1045e66c367ef240158eb7370ef16c560b3c1cba5595ff97033">+0/-9</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

